### PR TITLE
fix motor mount positioning example and doc 

### DIFF
--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -107,7 +107,7 @@ actAluminumChannel3_0( );
 // Attach the flipped child part (the clamp) by the specified position on the clamp,
 // to the specified position on the channel which is at the origin.
 moAttach( 0,                                               // origin
-          actAluminumChannel3_0Position( [ 0, 1, 6 ] ),    // position on channel
+          actAluminumChannel3_0Position( [ 2, 2, 25 ] ),    // position on channel
           moFlipPosition,                                  // flip the part
           actMotorMountClamping37Position( 3 ) )           // position on the clamp
   actMotorMountClamping37(  );

--- a/doc/userguide.md
+++ b/doc/userguide.md
@@ -107,7 +107,7 @@ actAluminumChannel3_0( );
 // Attach the flipped child part (the clamp) by the specified position on the clamp,
 // to the specified position on the channel which is at the origin.
 moAttach( 0,                                               // origin
-          actAluminumChannel3_0Position( [ 2, 2, 0 ] ),    // position on channel
+          actAluminumChannel3_0Position( [ 0, 1, 6 ] ),    // position on channel
           moFlipPosition,                                  // flip the part
           actMotorMountClamping37Position( 3 ) )           // position on the clamp
   actMotorMountClamping37(  );

--- a/examples/act3WheelRobot.scad
+++ b/examples/act3WheelRobot.scad
@@ -117,11 +117,11 @@ module act3WheelBot() {
   moAttach( swivel, swivelBase, castorJoint )
     act3WheelCastor();
 
-  driveChannelLeft = actAluminumChannel12Position( [ 14, 2, 0 ] );
+  driveChannelLeft = actAluminumChannel12Position( [ 14, 2, 25 ] );
   moAttach( driveChannel, driveChannelLeft, moFlipPosition )
     act3WheelDriveMotor( left = true );
 
-  driveChannelRight = actAluminumChannel12Position( [ 0, 2, 0 ] );
+  driveChannelRight = actAluminumChannel12Position( [ 0, 2, 6] );
   moAttach( driveChannel, driveChannelRight, moFlipPosition )
     act3WheelDriveMotor( left = false );
 


### PR DESCRIPTION
The example in the documentation does not place the motor clamp in the correct position.  Using:

```
          actAluminumChannel3_0Position( [ 2, 2, 0 ] ),    // position on channel
```

produces:

![image](https://cloud.githubusercontent.com/assets/1590761/9293710/418bcbd4-4403-11e5-8784-8f5b09bebd44.png)

The alignment is correct if, instead, this is used:

```
          actAluminumChannel3_0Position( [ 2, 2, 25 ] ),    // position on channel
```

as seen:

![image](https://cloud.githubusercontent.com/assets/1590761/9293733/22186108-4404-11e5-97a9-a399ed0de48e.png)

This is a minor fix.  Perhaps some conventions changed in the numbering of the positions.
